### PR TITLE
Check if $_SERVER indexes are set before calling them

### DIFF
--- a/uploads-by-proxy.php
+++ b/uploads-by-proxy.php
@@ -24,8 +24,8 @@ Version: 1.1.3
  */
 if ( !defined('UBP_IS_LOCAL') ) {
 	define('UBP_IS_LOCAL', (
-		( '127.0.0.1' == $_SERVER['SERVER_ADDR'] && '127.0.0.1' == $_SERVER['REMOTE_ADDR'] ) // IPv4
-		|| ( '::1' == $_SERVER['SERVER_ADDR'] && '::1' == $_SERVER['REMOTE_ADDR'] ) // IPv6
+		( isset( $_SERVER['SERVER_ADDR'] ) && '127.0.0.1' == $_SERVER['SERVER_ADDR'] && isset( $_SERVER['REMOTE_ADDR'] ) && '127.0.0.1' == $_SERVER['REMOTE_ADDR'] ) // IPv4
+		|| ( isset( $_SERVER['SERVER_ADDR'] ) && '::1' == $_SERVER['SERVER_ADDR'] && isset( $_SERVER['REMOTE_ADDR'] ) && '::1' == $_SERVER['REMOTE_ADDR'] ) // IPv6
 	) );
 }
 


### PR DESCRIPTION
These trigger a notice every time you call WP-CLI